### PR TITLE
remove github.com/agl/ed25519 #50

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha512"
 	"io"
 
-	"github.com/agl/ed25519"
 	"github.com/agl/ed25519/edwards25519"
 	"golang.org/x/crypto/curve25519"
 	ecdh "golang.org/x/crypto/ed25519"
@@ -154,7 +153,7 @@ func Verify(publicKey [32]byte, message []byte, signature *[64]byte) bool {
 	A_ed[31] |= signature[63] & 0x80
 	signature[63] &= 0x7F
 
-	return ed25519.Verify(&A_ed, message, signature)
+	return ecdh.Verify(A_ed[:], message, signature[:])
 }
 
 func LoadMaterialKey(chain []byte) ([]byte, error) {


### PR DESCRIPTION
I tested the command verify

````
(base) willy.aguirre@localhost:~/go/src/github.com/marti1125/pspk/bin$ ./pspk --name gato publish
Generate key pair on x25519
(base) willy.aguirre@localhost:~/go/src/github.com/marti1125/pspk/bin$ ./pspk --name gato sign test1
7TjprMbq1L0jKnAjE1EFDbBCjPkB51z+TaoXHfFCVY6BmJ+DndD6k5l5YPdabAnoge3HRt4lrVGv4tTE6PJHiA==
(base) willy.aguirre@localhost:~/go/src/github.com/marti1125/pspk/bin$ ./pspk verify gato 7TjprMbq1L0jKnAjE1EFDbBCjPkB51z+TaoXHfFCVY6BmJ+DndD6k5l5YPdabAnoge3HRt4lrVGv4tTE6PJHiA== test1
Signature 7TjprMbq1L0jKnAjE1EFDbBCjPkB51z+TaoXHfFCVY6BmJ+DndD6k5l5YPdabAnoge3HRt4lrVGv4tTE6PJHiA== is valid.
````